### PR TITLE
Update project tt_um_vga_clock (mattvenn/tt08-vga-clock)

### DIFF
--- a/projects/tt_um_vga_clock/commit_id.json
+++ b/projects/tt_um_vga_clock/commit_id.json
@@ -3,7 +3,7 @@
   "repo": "https://github.com/mattvenn/tt08-vga-clock",
   "commit": "97ec2cbcc19ea98e582b6762527f00247460f663",
   "workflow_url": "https://github.com/mattvenn/tt08-vga-clock/actions/runs/16321893471",
-  "sort_id": 1752675737575,
+  "sort_id": 1756895941493,
   "openlane_version": "OpenLane2 2.2.9",
   "pdk_name": "open_pdks",
   "pdk_version": "open_pdks 0fe599b2afb6708d281543108caf8310912f54af"


### PR DESCRIPTION
Update project tt_um_vga_clock to commit mattvenn/tt08-vga-clock@97ec2cbcc19ea98e582b6762527f00247460f663

Project title: VGA clock
Tiles: 1x1
Workflow: https://github.com/mattvenn/tt08-vga-clock/actions/runs/16321893471
Project submission: https://staging.tinytapeout-app.pages.dev/projects/101

