### PR TITLE
Update project tt_um_z2a_rgb_mixer (mattvenn/ttsky25a-rgb-mixer)

### DIFF
--- a/projects/tt_um_z2a_rgb_mixer/commit_id.json
+++ b/projects/tt_um_z2a_rgb_mixer/commit_id.json
@@ -3,7 +3,7 @@
   "repo": "https://github.com/mattvenn/ttsky25a-rgb-mixer",
   "commit": "424cad023dd67c9ea43c2155643a5780e27689dc",
   "workflow_url": "https://github.com/mattvenn/ttsky25a-rgb-mixer/actions/runs/16343107072",
-  "sort_id": 1752749833117,
+  "sort_id": 1756895996545,
   "openlane_version": "OpenLane2 2.2.9",
   "pdk_name": "open_pdks",
   "pdk_version": "open_pdks 0fe599b2afb6708d281543108caf8310912f54af"


### PR DESCRIPTION
Update project tt_um_z2a_rgb_mixer to commit mattvenn/ttsky25a-rgb-mixer@424cad023dd67c9ea43c2155643a5780e27689dc

Project title: RGB Mixer demo
Tiles: 1x1
Workflow: https://github.com/mattvenn/ttsky25a-rgb-mixer/actions/runs/16343107072
Project submission: https://staging.tinytapeout-app.pages.dev/projects/102

